### PR TITLE
Specify C++ standard in build command to fix compilation on macOS

### DIFF
--- a/build_analyzer.py
+++ b/build_analyzer.py
@@ -43,8 +43,8 @@ include_paths = [ "./AnalyzerSDK/include" ]
 link_paths = [ "./AnalyzerSDK/lib" ]
 link_dependencies = [ "-lAnalyzer" ] #refers to libAnalyzer.dylib or libAnalyzer.so
 
-debug_compile_flags = "-O0 -w -c -fpic -g"
-release_compile_flags = "-O3 -w -c -fpic"
+debug_compile_flags = "-std=c++11 -O0 -w -c -fpic -g"
+release_compile_flags = "-std=c++11 -O3 -w -c -fpic"
 
 def run_command(cmd):
     "Display cmd, then run it in a subshell, raise if there's an error"


### PR DESCRIPTION
I had issues building an analyzer on macOS because of C++ syntax errors. Adding this flag solved that problem for me. I'm using Apple LLVM version 10.0.1 (clang-1001.0.46.4).