### PR TITLE
Fix branch to LegacyAnalyzerSDK

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,4 @@
 [submodule "LegacyAnalyzerSDK"]
 	path = LegacyAnalyzerSDK
 	url = https://github.com/saleae/AnalyzerSDK.git
+	branch = 1.1.14-legacy


### PR DESCRIPTION
Use submodule branch 1.1.14-legacy for https://github.com/saleae/AnalyzerSDK.git instead of a fixed revision 160745b. Now the command 'git submodule update' can be used.