### PR TITLE
Add Apple Silicon Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,20 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
-        cmake --build ${{github.workspace}}/build
-    - name: Upload MacOS build
+        cmake -B ${{github.workspace}}/build/x86_64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=x86_64
+        cmake --build ${{github.workspace}}/build/x86_64
+        cmake -B ${{github.workspace}}/build/arm64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=arm64
+        cmake --build ${{github.workspace}}/build/arm64
+    - name: Upload MacOS x86_64 build
       uses: actions/upload-artifact@v2
       with:
-        name: macos
-        path: ${{github.workspace}}/build/Analyzers/*.so
+        name: macos_x86_64
+        path: ${{github.workspace}}/build/x86_64/Analyzers/*.so
+    - name: Upload MacOS arm64 build
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos_arm64
+        path: ${{github.workspace}}/build/arm64/Analyzers/*.so
   linux:
     runs-on: ubuntu-latest
     steps:
@@ -43,6 +50,9 @@ jobs:
       run: |
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
         cmake --build ${{github.workspace}}/build
+      env:
+        CC:   gcc-10
+        CXX:  g++-10
     - name: Upload Linux build
       uses: actions/upload-artifact@v2
       with:

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,8 @@
 
 - [Saleae Analyzer SDK Sample Analyzer](#saleae-analyzer-sdk-sample-analyzer)
   - [Renaming your Analyzer](#renaming-your-analyzer)
-  - [Cloud Building & Publishing](#cloud-building---publishing)
+  - [Cloud Building & Publishing](#cloud-building--publishing)
+    - [Apple Silicon Support](#apple-silicon-support)
   - [Prerequisites](#prerequisites)
     - [Windows](#windows)
     - [MacOS](#macos)
@@ -86,6 +87,37 @@ xattr -r -d com.apple.quarantine libSimpleSerialAnalyzer.so
 ```
 
 To verify the flag was removed, run the first command again and verify the quarantine flag is no longer present.
+
+### Apple Silicon Support
+
+Logic 2 now supports Apple Silicon natively!
+
+The included Github Actions integration, documented [here](#cloud-building---publishing), will automatically build your analyzer for both x86_64 and arm64 architectures, for MacOS.
+
+When you build your custom analyzer on a Mac, by default it will compile for the architecture of the system.
+
+Unfortunately, universal binaries are not currently supported.
+
+You can optionally cross build your analyzer using an x86_64 host system targeting arm64, or from a arm64 host system targeting x86_64.
+
+To cross build, you will need to create a new build directory (for example `build/x86_64` or `build/arm64`). Then use the CMake variable [CMAKE_OSX_ARCHITECTURES](https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_ARCHITECTURES.html).
+
+Examples:
+
+```bash
+mkdir -p build/arm64
+cd build/arm64
+cmake -DCMAKE_OSX_ARCHITECTURES=arm64 ..
+cmake --build .
+cd ../..
+# built analyzer will be located at SampleAnalyzer/build/arm64/Analyzers/libSimpleSerialAnalyzer.so
+mkdir -p build/x86_64
+cd build/x86_64
+cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 ..
+cmake --build .
+cd ../..
+# built analyzer will be located at SampleAnalyzer/build/x86_64/Analyzers/libSimpleSerialAnalyzer.so
+```
 
 ## Prerequisites
 

--- a/readme.md
+++ b/readme.md
@@ -107,13 +107,13 @@ Examples:
 ```bash
 mkdir -p build/arm64
 cd build/arm64
-cmake -DCMAKE_OSX_ARCHITECTURES=arm64 ..
+cmake -DCMAKE_OSX_ARCHITECTURES=arm64 ../..
 cmake --build .
 cd ../..
 # built analyzer will be located at SampleAnalyzer/build/arm64/Analyzers/libSimpleSerialAnalyzer.so
 mkdir -p build/x86_64
 cd build/x86_64
-cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 ..
+cmake -DCMAKE_OSX_ARCHITECTURES=x86_64 ../..
 cmake --build .
 cd ../..
 # built analyzer will be located at SampleAnalyzer/build/x86_64/Analyzers/libSimpleSerialAnalyzer.so

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ Dependencies:
 
 - Visual Studio 2017 (or newer) with C++
 - CMake 3.13+
+- git
 
 **Visual Studio 2017**
 
@@ -143,12 +144,17 @@ Note - if CMake has any problems with the MSVC compiler, it's likely a component
 Download and install the latest CMake release here.
 https://cmake.org/download/
 
+**git**
+
+Git is required for CMake to automatically download the AnalyzerSDK, which is a dependency of this project. Git can be downloaded here: https://git-scm.com/
+
 ### MacOS
 
 Dependencies:
 
 - XCode with command line tools
 - CMake 3.13+
+- git
 
 Installing command line tools after XCode is installed:
 
@@ -176,6 +182,7 @@ Dependencies:
 
 - CMake 3.13+
 - gcc 5+
+- git
 
 Misc dependencies:
 

--- a/sample_readme.md
+++ b/sample_readme.md
@@ -1,0 +1,99 @@
+# Cool 3rd Party Analyzer
+
+Original Readme Content Here
+
+Documentation for the Saleae Logic Analyzer SDK can be found here:
+https://github.com/saleae/SampleAnalyzer
+
+That documentation includes:
+
+- Detailed build instructions
+- Debugging instructions
+- Documentation for CI builds
+- Details on creating your own custom analyzer plugin
+
+# Installation Instructions
+
+To use this analyzer, simply download the latest release zip file from this github repository, unzip it, then install using the instructions found here:
+
+https://support.saleae.com/faq/technical-faq/setting-up-developer-directory
+
+# Publishing Releases
+
+This repository is setup with Github Actions to automatically build PRs and commits to the master branch.
+
+However, these artifacts automatically expire after a time limit.
+
+To create and publish cross-platform releases, simply push a commit tag. This will automatically trigger the creation of a release, which will include the Windows, Linux, and MacOS builds of the analyzer.
+
+# A note on downloading the MacOS Analyzer builds
+
+This section only applies to downloaded pre-built protocol analyzer binaries on MacOS. If you build the protocol analyzer locally, or acquire it in a different way, this section does not apply.
+
+Any time you download a binary from the internet on a Mac, wether it be an application or a shared library, MacOS will flag that binary for "quarantine". MacOS then requires any quarantined binary to be signed and notarized through the MacOS developer program before it will allow that binary to be executed.
+
+Because of this, when you download a pre-compiled protocol analyzer plugin from the internet and try to load it in the Saleae software, you will most likely see an error message like this:
+
+> "libSimpleSerialAnalyzer.so" cannot be opened because th developer cannot be verified.
+
+Signing and notarizing of open source software can be rare, because it requires an active paid subscription to the MacOS developer program, and the signing and notarization process frequently changes and becomes more restrictive, requiring frequent updates to the build process.
+
+The quickest solution to this is to simply remove the quarantine flag added by MacOS using a simple command line tool.
+
+Note - the purpose of code signing and notarization is to help end users be sure that the binary they downloaded did indeed come from the original publisher and hasn't been modified. Saleae does not create, control, or review 3rd party analyzer plugins available on the internet, and thus you must trust the original author and the website where you are downloading the plugin. (This applies to all software you've ever downloaded, essentially.)
+
+To remove the quarantine flag on MacOS, you can simply open the terminal and navigate to the directory containing the downloaded shared library.
+
+This will show what flags are present on the binary:
+
+```sh
+xattr libSimpleSerialAnalyzer.so
+# example output:
+# com.apple.macl
+# com.apple.quarantine
+```
+
+This command will remove the quarantine flag:
+
+```sh
+xattr -r -d com.apple.quarantine libSimpleSerialAnalyzer.so
+```
+
+To verify the flag was removed, run the first command again and verify the quarantine flag is no longer present.
+
+## Building your Analyzer
+
+CMake and a C++ compiler are required. Instructions for installing dependencies can be found here:
+https://github.com/saleae/SampleAnalyzer
+
+The fastest way to use this analyzer is to download a release from github. Local building should only be needed for making your own changes to the analyzer source.
+
+### Windows
+
+```bat
+mkdir build
+cd build
+cmake .. -A x64
+cmake --build .
+:: built analyzer will be located at SampleAnalyzer\build\Analyzers\Debug\SimpleSerialAnalyzer.dll
+```
+
+### MacOS
+
+```bash
+mkdir build
+cd build
+cmake ..
+cmake --build .
+# built analyzer will be located at SampleAnalyzer/build/Analyzers/libSimpleSerialAnalyzer.so
+```
+
+### Linux
+
+```bash
+mkdir build
+cd build
+cmake ..
+cmake --build .
+# built analyzer will be located at SampleAnalyzer/build/Analyzers/libSimpleSerialAnalyzer.so
+```


### PR DESCRIPTION
This PR will add native Apple Silicon support to the documentation.

Native Apple Silicon support has not shipped yet from Saleae. Once it ships, we need to merge this PR, and: https://github.com/saleae/AnalyzerSDK/pull/31

Also, all of our LLAs will need to be updated as well.