### PR TITLE
Remove dead member vars from SimpleSerialAnalyzer.h

### DIFF
--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -28,11 +28,6 @@ protected: //vars
 
 	SimpleSerialSimulationDataGenerator mSimulationDataGenerator;
 	bool mSimulationInitilized;
-
-	//Serial analysis vars:
-	U32 mSampleRateHz;
-	U32 mStartOfStopBitOffset;
-	U32 mEndOfStopBitOffset;
 };
 
 extern "C" ANALYZER_EXPORT const char* __cdecl GetAnalyzerName();


### PR DESCRIPTION
These were probably left over from an older version and are now unreferenced, and could be confusing to newbees looking at this sample template.

Probably best practice to keep all parser state local inside the worker thread anyway? Is there ever a good reason to modify the analyzer and results class headers? 