### PR TITLE
Remove std::auto_ptr

### DIFF
--- a/docs/Analyzer_API.md
+++ b/docs/Analyzer_API.md
@@ -673,8 +673,8 @@ extern "C" ANALYZER_EXPORT void __cdecl DestroyAnalyzer( Analyzer* analyzer );
 
 You’ll also need these member variables:
 ```c++
-std::auto_ptr< {YourName}AnalyzerSettings > mSettings;
-std::auto_ptr< {YourName}AnalyzerResults > mResults;
+{YourName}AnalyzerSettings mSettings;
+{YourName}AnalyzerResults mResults;
 {YourName}SimulationDataGenerator mSimulationDataGenerator;
 bool mSimulationInitialized;
 ```

--- a/docs/Analyzer_API.md
+++ b/docs/Analyzer_API.md
@@ -180,7 +180,7 @@ First, initialize all your settings variables to their default values.  Second, 
 
 ### Setting up each AnalyzerSettingInterface object
 
-Ee call the member function ```SetTitleAndTooltip()```. The title will appear to the left of the input element. Note that often times you won’t need a title, but you should use one for ```Channels```. The tooltip shows up when hovering over the input element.
+First, call the member function ```SetTitleAndTooltip()```. The title will appear to the left of the input element. Note that often times you won’t need a title, but you should use one for ```Channels```. The tooltip shows up when hovering over the input element.
 ```c++    
 void SetTitleAndTooltip( const char* title, const char* tooltip );
 mInputChannelInterface.SetTitleAndTooltip( "Serial", "Standard Async Serial" );

--- a/src/SimpleSerialAnalyzer.cpp
+++ b/src/SimpleSerialAnalyzer.cpp
@@ -4,10 +4,11 @@
 
 SimpleSerialAnalyzer::SimpleSerialAnalyzer()
 :	Analyzer2(),  
-	mSettings( new SimpleSerialAnalyzerSettings() ),
+	mSettings(),
+	mResults(this, &mSettings),
 	mSimulationInitilized( false )
 {
-	SetAnalyzerSettings( mSettings.get() );
+	SetAnalyzerSettings( &mSettings );
 }
 
 SimpleSerialAnalyzer::~SimpleSerialAnalyzer()
@@ -17,22 +18,23 @@ SimpleSerialAnalyzer::~SimpleSerialAnalyzer()
 
 void SimpleSerialAnalyzer::SetupResults()
 {
-	mResults.reset( new SimpleSerialAnalyzerResults( this, mSettings.get() ) );
-	SetAnalyzerResults( mResults.get() );
-	mResults->AddChannelBubblesWillAppearOn( mSettings->mInputChannel );
+	// SetupResults is called each time the analyzer is run. Because the same instance can be used for multiple runs, we need to clear the results each time.
+	mResults = SimpleSerialAnalyzerResults( this, &mSettings );
+	SetAnalyzerResults( &mResults );
+	mResults.AddChannelBubblesWillAppearOn( mSettings.mInputChannel );
 }
 
 void SimpleSerialAnalyzer::WorkerThread()
 {
 	mSampleRateHz = GetSampleRate();
 
-	mSerial = GetAnalyzerChannelData( mSettings->mInputChannel );
+	mSerial = GetAnalyzerChannelData( mSettings.mInputChannel );
 
 	if( mSerial->GetBitState() == BIT_LOW )
 		mSerial->AdvanceToNextEdge();
 
-	U32 samples_per_bit = mSampleRateHz / mSettings->mBitRate;
-	U32 samples_to_first_center_of_first_data_bit = U32( 1.5 * double( mSampleRateHz ) / double( mSettings->mBitRate ) );
+	U32 samples_per_bit = mSampleRateHz / mSettings.mBitRate;
+	U32 samples_to_first_center_of_first_data_bit = U32( 1.5 * double( mSampleRateHz ) / double( mSettings.mBitRate ) );
 
 	for( ; ; )
 	{
@@ -48,7 +50,7 @@ void SimpleSerialAnalyzer::WorkerThread()
 		for( U32 i=0; i<8; i++ )
 		{
 			//let's put a dot exactly where we sample this bit:
-			mResults->AddMarker( mSerial->GetSampleNumber(), AnalyzerResults::Dot, mSettings->mInputChannel );
+			mResults.AddMarker( mSerial->GetSampleNumber(), AnalyzerResults::Dot, mSettings.mInputChannel );
 
 			if( mSerial->GetBitState() == BIT_HIGH )
 				data |= mask;
@@ -66,8 +68,8 @@ void SimpleSerialAnalyzer::WorkerThread()
 		frame.mStartingSampleInclusive = starting_sample;
 		frame.mEndingSampleInclusive = mSerial->GetSampleNumber();
 
-		mResults->AddFrame( frame );
-		mResults->CommitResults();
+		mResults.AddFrame( frame );
+		mResults.CommitResults();
 		ReportProgress( frame.mEndingSampleInclusive );
 	}
 }
@@ -81,7 +83,7 @@ U32 SimpleSerialAnalyzer::GenerateSimulationData( U64 minimum_sample_index, U32 
 {
 	if( mSimulationInitilized == false )
 	{
-		mSimulationDataGenerator.Initialize( GetSimulationSampleRate(), mSettings.get() );
+		mSimulationDataGenerator.Initialize( GetSimulationSampleRate(), &mSettings );
 		mSimulationInitilized = true;
 	}
 
@@ -90,7 +92,7 @@ U32 SimpleSerialAnalyzer::GenerateSimulationData( U64 minimum_sample_index, U32 
 
 U32 SimpleSerialAnalyzer::GetMinimumSampleRateHz()
 {
-	return mSettings->mBitRate * 4;
+	return mSettings.mBitRate * 4;
 }
 
 const char* SimpleSerialAnalyzer::GetAnalyzerName() const

--- a/src/SimpleSerialAnalyzer.cpp
+++ b/src/SimpleSerialAnalyzer.cpp
@@ -5,7 +5,6 @@
 SimpleSerialAnalyzer::SimpleSerialAnalyzer()
 :	Analyzer2(),  
 	mSettings(),
-	mResults(this, &mSettings),
 	mSimulationInitilized( false )
 {
 	SetAnalyzerSettings( &mSettings );
@@ -19,9 +18,9 @@ SimpleSerialAnalyzer::~SimpleSerialAnalyzer()
 void SimpleSerialAnalyzer::SetupResults()
 {
 	// SetupResults is called each time the analyzer is run. Because the same instance can be used for multiple runs, we need to clear the results each time.
-	mResults = SimpleSerialAnalyzerResults( this, &mSettings );
-	SetAnalyzerResults( &mResults );
-	mResults.AddChannelBubblesWillAppearOn( mSettings.mInputChannel );
+	mResults.reset(new SimpleSerialAnalyzerResults( this, &mSettings ));
+	SetAnalyzerResults( mResults.get() );
+	mResults->AddChannelBubblesWillAppearOn( mSettings.mInputChannel );
 }
 
 void SimpleSerialAnalyzer::WorkerThread()
@@ -50,7 +49,7 @@ void SimpleSerialAnalyzer::WorkerThread()
 		for( U32 i=0; i<8; i++ )
 		{
 			//let's put a dot exactly where we sample this bit:
-			mResults.AddMarker( mSerial->GetSampleNumber(), AnalyzerResults::Dot, mSettings.mInputChannel );
+			mResults->AddMarker( mSerial->GetSampleNumber(), AnalyzerResults::Dot, mSettings.mInputChannel );
 
 			if( mSerial->GetBitState() == BIT_HIGH )
 				data |= mask;
@@ -68,8 +67,8 @@ void SimpleSerialAnalyzer::WorkerThread()
 		frame.mStartingSampleInclusive = starting_sample;
 		frame.mEndingSampleInclusive = mSerial->GetSampleNumber();
 
-		mResults.AddFrame( frame );
-		mResults.CommitResults();
+		mResults->AddFrame( frame );
+		mResults->CommitResults();
 		ReportProgress( frame.mEndingSampleInclusive );
 	}
 }

--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -5,6 +5,8 @@
 #include "SimpleSerialAnalyzerSettings.h"
 #include "SimpleSerialAnalyzerResults.h"
 #include "SimpleSerialSimulationDataGenerator.h"
+#include <memory>
+
 class ANALYZER_EXPORT SimpleSerialAnalyzer : public Analyzer2
 {
 public:
@@ -22,7 +24,7 @@ public:
 
 protected: //vars
 	SimpleSerialAnalyzerSettings mSettings;
-	SimpleSerialAnalyzerResults mResults;
+	std::unique_ptr<SimpleSerialAnalyzerResults> mResults;
 	AnalyzerChannelData* mSerial;
 
 	SimpleSerialSimulationDataGenerator mSimulationDataGenerator;

--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -2,10 +2,9 @@
 #define SIMPLESERIAL_ANALYZER_H
 
 #include <Analyzer.h>
+#include "SimpleSerialAnalyzerSettings.h"
 #include "SimpleSerialAnalyzerResults.h"
 #include "SimpleSerialSimulationDataGenerator.h"
-
-class SimpleSerialAnalyzerSettings;
 class ANALYZER_EXPORT SimpleSerialAnalyzer : public Analyzer2
 {
 public:

--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -22,8 +22,8 @@ public:
 	virtual bool NeedsRerun();
 
 protected: //vars
-	std::auto_ptr< SimpleSerialAnalyzerSettings > mSettings;
-	std::auto_ptr< SimpleSerialAnalyzerResults > mResults;
+	SimpleSerialAnalyzerSettings mSettings;
+	SimpleSerialAnalyzerResults mResults;
 	AnalyzerChannelData* mSerial;
 
 	SimpleSerialSimulationDataGenerator mSimulationDataGenerator;

--- a/src/SimpleSerialAnalyzerSettings.cpp
+++ b/src/SimpleSerialAnalyzerSettings.cpp
@@ -4,20 +4,20 @@
 
 SimpleSerialAnalyzerSettings::SimpleSerialAnalyzerSettings()
 :	mInputChannel( UNDEFINED_CHANNEL ),
-	mBitRate( 9600 )
+	mBitRate( 9600 ),
+	mInputChannelInterface(),
+	mBitRateInterface()
 {
-	mInputChannelInterface.reset( new AnalyzerSettingInterfaceChannel() );
-	mInputChannelInterface->SetTitleAndTooltip( "Serial", "Standard Simple Serial" );
-	mInputChannelInterface->SetChannel( mInputChannel );
+	mInputChannelInterface.SetTitleAndTooltip( "Serial", "Standard Simple Serial" );
+	mInputChannelInterface.SetChannel( mInputChannel );
 
-	mBitRateInterface.reset( new AnalyzerSettingInterfaceInteger() );
-	mBitRateInterface->SetTitleAndTooltip( "Bit Rate (Bits/S)",  "Specify the bit rate in bits per second." );
-	mBitRateInterface->SetMax( 6000000 );
-	mBitRateInterface->SetMin( 1 );
-	mBitRateInterface->SetInteger( mBitRate );
+	mBitRateInterface.SetTitleAndTooltip( "Bit Rate (Bits/S)",  "Specify the bit rate in bits per second." );
+	mBitRateInterface.SetMax( 6000000 );
+	mBitRateInterface.SetMin( 1 );
+	mBitRateInterface.SetInteger( mBitRate );
 
-	AddInterface( mInputChannelInterface.get() );
-	AddInterface( mBitRateInterface.get() );
+	AddInterface( &mInputChannelInterface );
+	AddInterface( &mBitRateInterface );
 
 	AddExportOption( 0, "Export as text/csv file" );
 	AddExportExtension( 0, "text", "txt" );
@@ -33,8 +33,8 @@ SimpleSerialAnalyzerSettings::~SimpleSerialAnalyzerSettings()
 
 bool SimpleSerialAnalyzerSettings::SetSettingsFromInterfaces()
 {
-	mInputChannel = mInputChannelInterface->GetChannel();
-	mBitRate = mBitRateInterface->GetInteger();
+	mInputChannel = mInputChannelInterface.GetChannel();
+	mBitRate = mBitRateInterface.GetInteger();
 
 	ClearChannels();
 	AddChannel( mInputChannel, "Simple Serial", true );
@@ -44,8 +44,8 @@ bool SimpleSerialAnalyzerSettings::SetSettingsFromInterfaces()
 
 void SimpleSerialAnalyzerSettings::UpdateInterfacesFromSettings()
 {
-	mInputChannelInterface->SetChannel( mInputChannel );
-	mBitRateInterface->SetInteger( mBitRate );
+	mInputChannelInterface.SetChannel( mInputChannel );
+	mBitRateInterface.SetInteger( mBitRate );
 }
 
 void SimpleSerialAnalyzerSettings::LoadSettings( const char* settings )

--- a/src/SimpleSerialAnalyzerSettings.h
+++ b/src/SimpleSerialAnalyzerSettings.h
@@ -20,8 +20,8 @@ public:
 	U32 mBitRate;
 
 protected:
-	std::auto_ptr< AnalyzerSettingInterfaceChannel >	mInputChannelInterface;
-	std::auto_ptr< AnalyzerSettingInterfaceInteger >	mBitRateInterface;
+	AnalyzerSettingInterfaceChannel	mInputChannelInterface;
+	AnalyzerSettingInterfaceInteger	mBitRateInterface;
 };
 
 #endif //SIMPLESERIAL_ANALYZER_SETTINGS


### PR DESCRIPTION
auto_ptr was the wrong tool for the job when we first started the Analyzer API many years ago. This PR removes it.

We now use std::unique_ptr for the Results member, because that needs to get reset each time the analyzer is re-run for a single instance of the analyzer class.

https://github.com/saleae/SampleAnalyzer/issues/32