### PR TITLE
Suppress warnings about stl data members in dllexport classes.

### DIFF
--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -24,7 +24,10 @@ public:
 
 protected: //vars
 	SimpleSerialAnalyzerSettings mSettings;
+#pragma warning( push )
+#pragma warning( disable : 4251 ) // warning C4251: ... needs to have dll-interface to be used by clients of class
 	std::unique_ptr<SimpleSerialAnalyzerResults> mResults;
+#pragma warning( pop )
 	AnalyzerChannelData* mSerial;
 
 	SimpleSerialSimulationDataGenerator mSimulationDataGenerator;

--- a/src/SimpleSerialAnalyzerResults.h
+++ b/src/SimpleSerialAnalyzerResults.h
@@ -6,7 +6,7 @@
 class SimpleSerialAnalyzer;
 class SimpleSerialAnalyzerSettings;
 
-class SimpleSerialAnalyzerResults : public AnalyzerResults
+class ANALYZER_EXPORT SimpleSerialAnalyzerResults : public AnalyzerResults
 {
 public:
 	SimpleSerialAnalyzerResults( SimpleSerialAnalyzer* analyzer, SimpleSerialAnalyzerSettings* settings );

--- a/src/SimpleSerialAnalyzerSettings.h
+++ b/src/SimpleSerialAnalyzerSettings.h
@@ -4,7 +4,7 @@
 #include <AnalyzerSettings.h>
 #include <AnalyzerTypes.h>
 
-class SimpleSerialAnalyzerSettings : public AnalyzerSettings
+class ANALYZER_EXPORT SimpleSerialAnalyzerSettings : public AnalyzerSettings
 {
 public:
 	SimpleSerialAnalyzerSettings();

--- a/src/SimpleSerialSimulationDataGenerator.h
+++ b/src/SimpleSerialSimulationDataGenerator.h
@@ -5,7 +5,7 @@
 #include <string>
 class SimpleSerialAnalyzerSettings;
 
-class SimpleSerialSimulationDataGenerator
+class ANALYZER_EXPORT SimpleSerialSimulationDataGenerator
 {
 public:
 	SimpleSerialSimulationDataGenerator();
@@ -20,7 +20,10 @@ protected:
 
 protected:
 	void CreateSerialByte();
+#pragma warning( push )
+#pragma warning( disable : 4251 ) // warning C4251: ... needs to have dll-interface to be used by clients of class
 	std::string mSerialText;
+#pragma warning( pop )
 	U32 mStringIndex;
 
 	SimulationChannelDescriptor mSerialSimulationData;


### PR DESCRIPTION
Demonstration purposes only, attempt to get build down to zero warnings.