### PR TITLE
Remove dead members (based on #28)

### DIFF
--- a/src/SimpleSerialAnalyzer.cpp
+++ b/src/SimpleSerialAnalyzer.cpp
@@ -25,15 +25,15 @@ void SimpleSerialAnalyzer::SetupResults()
 
 void SimpleSerialAnalyzer::WorkerThread()
 {
-	mSampleRateHz = GetSampleRate();
+	U32 sample_rate_hz = GetSampleRate();
 
 	mSerial = GetAnalyzerChannelData( mSettings.mInputChannel );
 
 	if( mSerial->GetBitState() == BIT_LOW )
 		mSerial->AdvanceToNextEdge();
 
-	U32 samples_per_bit = mSampleRateHz / mSettings.mBitRate;
-	U32 samples_to_first_center_of_first_data_bit = U32( 1.5 * double( mSampleRateHz ) / double( mSettings.mBitRate ) );
+	U32 samples_per_bit = sample_rate_hz / mSettings.mBitRate;
+	U32 samples_to_first_center_of_first_data_bit = U32( 1.5 * double( sample_rate_hz ) / double( mSettings.mBitRate ) );
 
 	for( ; ; )
 	{

--- a/src/SimpleSerialAnalyzer.h
+++ b/src/SimpleSerialAnalyzer.h
@@ -29,11 +29,6 @@ protected: //vars
 
 	SimpleSerialSimulationDataGenerator mSimulationDataGenerator;
 	bool mSimulationInitilized;
-
-	//Serial analysis vars:
-	U32 mSampleRateHz;
-	U32 mStartOfStopBitOffset;
-	U32 mEndOfStopBitOffset;
 };
 
 extern "C" ANALYZER_EXPORT const char* __cdecl GetAnalyzerName();


### PR DESCRIPTION
Basically, the same as this PR: https://github.com/saleae/SampleAnalyzer/pull/28

but with the removal of the use of mSampleRateHz from SimpleSerialAnalyzer.cpp.

I still need to actually build and test this.